### PR TITLE
🔧 Use module.exports instead of export default

### DIFF
--- a/packages/server/knexfile.ts
+++ b/packages/server/knexfile.ts
@@ -1,6 +1,6 @@
 import { config } from "./src/config";
 
-export default {
+module.exports = {
   client: config.database.database_client,
   connection: config.database.database_url,
   pool: {

--- a/packages/server/src/db/db.ts
+++ b/packages/server/src/db/db.ts
@@ -1,5 +1,5 @@
 import Knex from "knex";
-import knexConfig from "../../knexfile";
+import * as knexConfig from "../../knexfile";
 
 export const knex = Knex(knexConfig);
 


### PR DESCRIPTION
This fixes scripts like `yarn server migrate` or `yarn server seeds`﻿
