### PR TITLE
feat(Bookings&Houses): Instantly refresh lists UI on booking/house creation/cancellation

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -10,8 +10,10 @@
     "eject": "react-scripts eject"
   },
   "dependencies": {
+    "@date-io/date-fns": "1.3.13",
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
+    "@material-ui/pickers": "^3.2.10",
     "axios": "^0.19.2",
     "date-fns": "^2.12.0",
     "grommet": "^2.13.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -26,7 +26,8 @@
     "react-dom": "^16.13.1",
     "react-hook-form": "^5.7.2",
     "react-router-dom": "^5.2.0",
-    "styled-components": "^5.2.0"
+    "styled-components": "^5.2.0",
+    "uuid": "^8.3.1"
   },
   "devDependencies": {
     "@testing-library/dom": "^7.22.1",
@@ -41,6 +42,7 @@
     "@types/react-dom": "^16.9.0",
     "@types/react-router-dom": "^5.1.5",
     "@types/styled-components": "^5.1.4",
+    "@types/uuid": "^8.3.0",
     "mockdate": "^3.0.2",
     "mutationobserver-shim": "^0.3.5",
     "react-scripts": "3.4.3",

--- a/packages/client/src/AuthenticatedApp.tsx
+++ b/packages/client/src/AuthenticatedApp.tsx
@@ -6,6 +6,7 @@ import { useAuth } from "./contexts/AuthContext";
 import { Switch, Route, Redirect } from "react-router-dom";
 import { Dashboard } from "./pages/Dashboard";
 import { HouseSpace } from "./pages/HouseSpace";
+
 import {
   AppBar,
   Button,

--- a/packages/client/src/components/BookingsList/BookingsList.tsx
+++ b/packages/client/src/components/BookingsList/BookingsList.tsx
@@ -7,18 +7,27 @@ import {
   CardActions,
   CardContent,
   Divider,
+  Drawer,
+  Fab,
   GridList,
   GridListTile,
   makeStyles,
+  Tooltip,
   Typography,
 } from "@material-ui/core";
+import AddIcon from "@material-ui/icons/Add";
 
 import { useAsync } from "../../hooks/useAsync";
-import { Booking } from "../../types";
+import { Booking, House } from "../../types";
 import { FullPageErrorFallback } from "../FullPageErrorCallback";
 import { FullPageSpinner } from "../FullPageSpinner";
 import { formatDate } from "../../utils/calendar";
 import { serializeBooking } from "../../utils/bookings";
+import { NewBookingForm } from "../NewBookingForm";
+
+interface Props {
+  houses?: House[];
+}
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -36,14 +45,28 @@ const useStyles = makeStyles(() => ({
   icon: {
     color: "rgba(255, 255, 255, 0.54)",
   },
+  title: {
+    display: "flex",
+    justifyContent: "space-between",
+  },
 }));
 
-export const BookingsList = () => {
+export const BookingsList = ({ houses }: Props) => {
   const { data: bookings, run, isIdle, isLoading, isError, error } = useAsync<
     Booking[] | null
   >();
 
   const classes = useStyles();
+
+  const [open, setOpen] = React.useState(false);
+
+  const handleClickOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
 
   useLayoutEffect(() => {
     const getBookings = async (): Promise<Booking[]> => {
@@ -73,13 +96,37 @@ export const BookingsList = () => {
 
   return (
     <>
-      <Typography variant="h4" align="left" gutterBottom>
+      <Drawer
+        open={open}
+        anchor="right"
+        onClose={handleClose}
+        variant="temporary"
+      >
+        <NewBookingForm handleClose={handleClose} houses={houses} />
+      </Drawer>
+      <Typography
+        className={classes.title}
+        variant="h4"
+        align="left"
+        gutterBottom
+      >
         Your bookings
+        <Tooltip
+          title="Add"
+          aria-label="add"
+          placement="right"
+          onClick={handleClickOpen}
+        >
+          <Fab color="primary" size="small">
+            <AddIcon />
+          </Fab>
+        </Tooltip>
       </Typography>
+
       <GridList cellHeight={180} className={classes.gridList} spacing={15}>
         {bookings.map((booking) => {
           return (
-            <GridListTile>
+            <GridListTile key={booking.bookingId}>
               <Card>
                 <CardContent>
                   <Typography gutterBottom component="h5" align="center">
@@ -91,7 +138,6 @@ export const BookingsList = () => {
                     component="p"
                   >
                     {formatDate(booking.arrivalTime)}
-                    {/* {formatDate(booking.departureTime)} */}
                   </Typography>
                   <Typography
                     variant="body2"

--- a/packages/client/src/components/BookingsList/BookingsList.tsx
+++ b/packages/client/src/components/BookingsList/BookingsList.tsx
@@ -68,6 +68,17 @@ export const BookingsList = ({ houses }: Props) => {
     setOpen(false);
   };
 
+  const handleBookingCancellation = async (
+    bookingId: string,
+  ): Promise<void> => {
+    await Axios.delete(
+      `${process.env.REACT_APP_SERVER_URL}/bookings/${bookingId}`,
+      {
+        withCredentials: true,
+      },
+    );
+  };
+
   useLayoutEffect(() => {
     const getBookings = async (): Promise<Booking[]> => {
       const response = await Axios.get(
@@ -149,7 +160,12 @@ export const BookingsList = ({ houses }: Props) => {
                 </CardContent>
                 <Divider light />
                 <CardActions>
-                  <Button size="small" color="primary" fullWidth>
+                  <Button
+                    size="small"
+                    color="primary"
+                    fullWidth
+                    onClick={() => handleBookingCancellation(booking.bookingId)}
+                  >
                     Cancel
                   </Button>
                 </CardActions>

--- a/packages/client/src/components/Calendar/CalendarHeading/CalendarHeading.tsx
+++ b/packages/client/src/components/Calendar/CalendarHeading/CalendarHeading.tsx
@@ -4,7 +4,7 @@ import { WEEK_DAYS_NAMES } from "../../../utils/constants";
 
 export const CalendarHeading = () => {
   return (
-    <React.Fragment>
+    <>
       {WEEK_DAYS_NAMES.map((name) => (
         <Box alignSelf="center" key={name}>
           <Heading alignSelf="center" level="5">
@@ -12,6 +12,6 @@ export const CalendarHeading = () => {
           </Heading>
         </Box>
       ))}
-    </React.Fragment>
+    </>
   );
 };

--- a/packages/client/src/components/HousesList/HousesList.tsx
+++ b/packages/client/src/components/HousesList/HousesList.tsx
@@ -11,12 +11,22 @@ import {
   CardActions,
   CardContent,
   Divider,
+  Drawer,
+  Fab,
   GridList,
   GridListTile,
   makeStyles,
+  Tooltip,
   Typography,
 } from "@material-ui/core";
+import AddIcon from "@material-ui/icons/Add";
+
 import { Link } from "react-router-dom";
+import { NewHouseForm } from "../NewHouseForm";
+
+interface Props {
+  retrieveHousesForBookingForm: (houses: House[]) => void;
+}
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -35,13 +45,27 @@ const useStyles = makeStyles((theme) => ({
   icon: {
     color: "rgba(255, 255, 255, 0.54)",
   },
+  title: {
+    display: "flex",
+    justifyContent: "space-between",
+  },
 }));
 
-export const HousesList = () => {
+export const HousesList = ({ retrieveHousesForBookingForm }: Props) => {
   const { data: houses, run, isIdle, isLoading, isError, error } = useAsync<
     House[] | null
   >();
   const classes = useStyles();
+
+  const [open, setOpen] = React.useState(false);
+
+  const handleClickOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
 
   useLayoutEffect(() => {
     const getHouses = async (): Promise<House[]> => {
@@ -56,6 +80,7 @@ export const HousesList = () => {
         return [];
       }
 
+      retrieveHousesForBookingForm(response.data.houses);
       return response.data.houses;
     };
     run(getHouses());
@@ -71,12 +96,35 @@ export const HousesList = () => {
 
   return (
     <>
-      <Typography variant="h4" align="left" gutterBottom>
+      <Drawer
+        open={open}
+        anchor="right"
+        onClose={handleClose}
+        variant="temporary"
+      >
+        <NewHouseForm handleClose={handleClose} />
+      </Drawer>
+      <Typography
+        variant="h4"
+        align="left"
+        gutterBottom
+        className={classes.title}
+      >
         Your houses
+        <Tooltip
+          title="Add"
+          aria-label="add"
+          placement="right"
+          onClick={handleClickOpen}
+        >
+          <Fab color="primary" size="small">
+            <AddIcon />
+          </Fab>
+        </Tooltip>
       </Typography>
       <GridList cellHeight={180} className={classes.gridList} spacing={15}>
         {houses.map((house) => (
-          <GridListTile>
+          <GridListTile key={house.houseId}>
             <Card>
               <CardContent>
                 <Typography

--- a/packages/client/src/components/NewBookingForm/NewBookingForm.tsx
+++ b/packages/client/src/components/NewBookingForm/NewBookingForm.tsx
@@ -1,0 +1,202 @@
+import React from "react";
+import {
+  Button,
+  FormControl,
+  makeStyles,
+  MenuItem,
+  Select,
+  TextField,
+  Typography,
+} from "@material-ui/core";
+import { useForm, OnSubmit, Controller } from "react-hook-form";
+
+import Axios from "axios";
+import { House } from "../../types";
+import { createNewDateFromString } from "../../utils/calendar";
+import { newBookingFieldsErrorsMapping } from "../../utils/bookings";
+
+interface NewBookingData {
+  houseId: string;
+  arrivalTime: string;
+  departureTime: string;
+  comments: string;
+  numberOfPeople: string;
+}
+
+interface Props {
+  handleClose: () => void;
+  houses?: House[];
+}
+
+const useStyles = makeStyles((theme) => ({
+  title: {
+    marginTop: "20px",
+  },
+  root: {
+    width: "350px",
+    display: "flex",
+    alignItems: "center",
+    marginTop: "10px",
+  },
+  field: {
+    width: "200px",
+    marginBottom: "20px",
+  },
+}));
+
+export const NewBookingForm = ({ handleClose, houses }: Props) => {
+  const classes = useStyles();
+
+  const { handleSubmit, setError, errors, control } = useForm<NewBookingData>();
+
+  const onSubmit: OnSubmit<NewBookingData> = async (data) => {
+    try {
+      const newBookingData = {
+        arrivalTime: createNewDateFromString(data.arrivalTime),
+        departureTime: createNewDateFromString(data.departureTime),
+        comments: data.comments,
+        companions: parseInt(data.numberOfPeople, 10),
+      };
+
+      await Axios(
+        `${process.env.REACT_APP_SERVER_URL}/houses/${data.houseId}/bookings/booking`,
+        {
+          method: "post",
+          data: newBookingData,
+          withCredentials: true,
+        },
+      );
+      handleClose();
+    } catch (error) {
+      setError("departureTime", "generalInvalidMessage");
+      setError("arrivalTime", "generalInvalidMessage");
+      setError("comments", "generalInvalidMessage");
+      setError("numberOfPeople", "generalInvalidMessage");
+      setError("houseId", "generalInvalidMessage");
+    }
+  };
+
+  return (
+    <>
+      <Typography
+        className={classes.title}
+        variant="h5"
+        align="center"
+        gutterBottom
+      >
+        Create a new booking
+      </Typography>
+      <FormControl
+        className={classes.root}
+        onSubmit={handleSubmit(onSubmit)}
+        margin="dense"
+        fullWidth
+      >
+        <Controller
+          className={classes.field}
+          as={
+            <Select
+              labelId="demo-simple-select-outlined-label"
+              id="demo-simple-select-outlined"
+              label="House"
+            >
+              {houses?.map((house) => {
+                return (
+                  <MenuItem
+                    key={house.houseId}
+                    defaultValue=""
+                    value={house.houseId}
+                  >
+                    {house.name}
+                  </MenuItem>
+                );
+              })}
+            </Select>
+          }
+          variant="outlined"
+          label="House"
+          name="houseId"
+          control={control}
+          error={!!errors.houseId}
+          helperText={
+            !!errors.houseId
+              ? newBookingFieldsErrorsMapping["generalInvalidMessage"]
+              : ""
+          }
+          defaultValue=""
+        />
+        <Controller
+          className={classes.field}
+          as={TextField}
+          variant="outlined"
+          label="Number of people"
+          name="numberOfPeople"
+          control={control}
+          error={!!errors.numberOfPeople}
+          helperText={
+            !!errors.numberOfPeople
+              ? newBookingFieldsErrorsMapping["generalInvalidMessage"]
+              : ""
+          }
+          defaultValue=""
+        />
+        <Controller
+          className={classes.field}
+          as={TextField}
+          variant="outlined"
+          label="Comments"
+          name="comments"
+          control={control}
+          error={!!errors.comments}
+          helperText={
+            !!errors.comments
+              ? newBookingFieldsErrorsMapping["generalInvalidMessage"]
+              : ""
+          }
+          defaultValue=""
+        />
+        <Controller
+          className={classes.field}
+          as={TextField}
+          variant="outlined"
+          label="Arrival Date"
+          name="arrivalTime"
+          control={control}
+          error={!!errors.arrivalTime}
+          helperText={
+            !!errors.arrivalTime
+              ? newBookingFieldsErrorsMapping["generalInvalidMessage"]
+              : ""
+          }
+          placeholder="dd/mm/yyyy"
+          defaultValue=""
+        />
+        <Controller
+          className={classes.field}
+          as={TextField}
+          variant="outlined"
+          label="Departure Date"
+          name="departureTime"
+          control={control}
+          error={!!errors.departureTime}
+          helperText={
+            !!errors.departureTime
+              ? newBookingFieldsErrorsMapping["generalInvalidMessage"]
+              : ""
+          }
+          placeholder="dd/mm/yyyy"
+          defaultValue=""
+        />
+
+        <Button
+          size="small"
+          variant="outlined"
+          color="primary"
+          onClick={handleSubmit(onSubmit)}
+        >
+          Create
+        </Button>
+      </FormControl>
+    </>
+  );
+};

--- a/packages/client/src/components/NewBookingForm/index.ts
+++ b/packages/client/src/components/NewBookingForm/index.ts
@@ -1,0 +1,1 @@
+export * from "./NewBookingForm";

--- a/packages/client/src/components/NewHouseForm/NewHouseForm.tsx
+++ b/packages/client/src/components/NewHouseForm/NewHouseForm.tsx
@@ -1,0 +1,98 @@
+import React from "react";
+import {
+  Button,
+  FormControl,
+  makeStyles,
+  TextField,
+  Typography,
+} from "@material-ui/core";
+import { useForm, OnSubmit, Controller } from "react-hook-form";
+
+import Axios from "axios";
+import { newHouseFieldsErrorsMapping } from "../../utils/houses";
+
+type NewHouseData = { name: string };
+
+interface Props {
+  handleClose: () => void;
+}
+
+const useStyles = makeStyles((theme) => ({
+  title: {
+    marginTop: "20px",
+  },
+  root: {
+    width: "350px",
+    display: "flex",
+    alignItems: "center",
+    marginTop: "10px",
+  },
+  field: {
+    width: "200px",
+    marginBottom: "20px",
+  },
+}));
+
+export const NewHouseForm = ({ handleClose }: Props) => {
+  const classes = useStyles();
+
+  const { handleSubmit, setError, errors, control } = useForm<NewHouseData>();
+
+  const onSubmit: OnSubmit<NewHouseData> = async (data) => {
+    try {
+      await Axios(`${process.env.REACT_APP_SERVER_URL}/houses/house`, {
+        method: "post",
+        data: {
+          name: data.name,
+        },
+        withCredentials: true,
+      });
+      handleClose();
+    } catch (error) {
+      setError("name", "wrongHouseName");
+    }
+  };
+
+  return (
+    <>
+      <Typography
+        className={classes.title}
+        variant="h5"
+        align="center"
+        gutterBottom
+      >
+        Create a new house
+      </Typography>
+      <FormControl
+        className={classes.root}
+        onSubmit={handleSubmit(onSubmit)}
+        margin="dense"
+        fullWidth
+      >
+        <Controller
+          className={classes.field}
+          as={TextField}
+          variant="outlined"
+          label="House name"
+          name="name"
+          control={control}
+          error={!!errors.name}
+          helperText={
+            !!errors.name
+              ? newHouseFieldsErrorsMapping["generalInvalidMessage"]
+              : ""
+          }
+        />
+
+        <Button
+          size="small"
+          variant="outlined"
+          color="primary"
+          onClick={handleSubmit(onSubmit)}
+        >
+          Create
+        </Button>
+      </FormControl>
+    </>
+  );
+};

--- a/packages/client/src/components/NewHouseForm/NewHouseForm.tsx
+++ b/packages/client/src/components/NewHouseForm/NewHouseForm.tsx
@@ -7,14 +7,17 @@ import {
   Typography,
 } from "@material-ui/core";
 import { useForm, OnSubmit, Controller } from "react-hook-form";
+import { v4 as uuidv4 } from "uuid";
 
 import Axios from "axios";
 import { newHouseFieldsErrorsMapping } from "../../utils/houses";
+import { House } from "../../types";
 
 type NewHouseData = { name: string };
 
 interface Props {
   handleClose: () => void;
+  addNewHouseToDisplayList: (newHouse: House) => void;
 }
 
 const useStyles = makeStyles((theme) => ({
@@ -33,18 +36,25 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export const NewHouseForm = ({ handleClose }: Props) => {
+export const NewHouseForm = ({
+  handleClose,
+  addNewHouseToDisplayList,
+}: Props) => {
   const classes = useStyles();
 
   const { handleSubmit, setError, errors, control } = useForm<NewHouseData>();
 
   const onSubmit: OnSubmit<NewHouseData> = async (data) => {
     try {
+      const houseId = uuidv4();
+      const newHouse = {
+        houseId,
+        name: data.name,
+      };
+      addNewHouseToDisplayList(newHouse);
       await Axios(`${process.env.REACT_APP_SERVER_URL}/houses/house`, {
         method: "post",
-        data: {
-          name: data.name,
-        },
+        data: newHouse,
         withCredentials: true,
       });
       handleClose();

--- a/packages/client/src/components/NewHouseForm/index.ts
+++ b/packages/client/src/components/NewHouseForm/index.ts
@@ -1,0 +1,1 @@
+export * from "./NewHouseForm";

--- a/packages/client/src/pages/Dashboard/Dashboard.tsx
+++ b/packages/client/src/pages/Dashboard/Dashboard.tsx
@@ -4,8 +4,15 @@ import { HousesList } from "../../components/HousesList/HousesList";
 import { BookingsList } from "../../components/BookingsList/BookingsList";
 import Grid from "@material-ui/core/Grid";
 import { Typography } from "@material-ui/core";
+import { House } from "../../types";
 
 export const Dashboard = () => {
+  const [houses, setHouses] = React.useState<House[]>();
+
+  const retrieveHousesForBookingForm = (houses: House[]) => {
+    setHouses(houses);
+  };
+
   return (
     <>
       <Typography variant="h3" align="left" gutterBottom>
@@ -13,10 +20,12 @@ export const Dashboard = () => {
       </Typography>
       <Grid container justify="space-evenly" spacing={3}>
         <Grid item>
-          <HousesList />
+          <HousesList
+            retrieveHousesForBookingForm={retrieveHousesForBookingForm}
+          />
         </Grid>
         <Grid item>
-          <BookingsList />
+          <BookingsList houses={houses} />
         </Grid>
       </Grid>
     </>

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -14,3 +14,19 @@ export interface House {
   houseId: string;
   name: string;
 }
+
+export interface NewBookingData {
+  houseId: string;
+  arrivalTime: string;
+  departureTime: string;
+  comments: string;
+  companions: string;
+}
+
+export interface NewBookingBody {
+  bookingId: string;
+  arrivalTime: Date;
+  departureTime: Date;
+  comments: string;
+  companions: number;
+}

--- a/packages/client/src/utils/bookings.ts
+++ b/packages/client/src/utils/bookings.ts
@@ -12,3 +12,13 @@ export const serializeBooking = (rawBooking: Record<string, any>): Booking => ({
   companions: rawBooking.companions,
   houseName: rawBooking.houseName,
 });
+
+export const newBookingFieldsErrorsMapping: { [key: string]: string } = {
+  "generalInvalidMessage": "This field might be wrong",
+  "required": "This field can't be empty",
+  "wrongHouseName": "This house name is incorrect",
+  "wrongComments": "This comment is invalid",
+  "wrongNumberOfPeople": "This number of people is invalid",
+  "wrongArrivalTime": "This arrival date is incorrect",
+  "departureTime": "This departure date is incorrect",
+};

--- a/packages/client/src/utils/calendar.ts
+++ b/packages/client/src/utils/calendar.ts
@@ -1,4 +1,4 @@
-import { format } from "date-fns";
+import { format, parse } from "date-fns";
 import range from "lodash/range";
 
 export const getRandomIntegerInclusive = (min: number, max: number) => {
@@ -10,3 +10,6 @@ export const repeat = (length: number, ret: string) =>
   range(length).map(() => ret);
 
 export const formatDate = (date: Date) => format(date, "EEEE dd MMM yyyy");
+
+export const createNewDateFromString = (date: string): Date =>
+  parse(date, "dd/MM/yyyy", new Date());

--- a/packages/client/src/utils/houses.ts
+++ b/packages/client/src/utils/houses.ts
@@ -1,0 +1,5 @@
+export const newHouseFieldsErrorsMapping: { [key: string]: string } = {
+  "generalInvalidMessage": "This field might be wrong",
+  "required": "This field can't be empty",
+  "wrongHouseName": "This house name is incorrect",
+};

--- a/packages/server/src/controllers/bookings.integration.test.ts
+++ b/packages/server/src/controllers/bookings.integration.test.ts
@@ -38,11 +38,13 @@ describe("Bookings", () => {
     password: "password",
   };
 
-  const mockHouseData = {
+  const mockHouseData1 = {
+    houseId: "a5d72994-80eb-45c7-8351-c3e0fa3c3d80",
     name: "Longwood House",
   };
 
   const mockHouseData2 = {
+    houseId: "a5d72994-80eb-45c7-8351-c3e0fa3c3d81",
     name: "La Confiance",
   };
 
@@ -55,11 +57,18 @@ describe("Bookings", () => {
         mockNewAccountData.password,
       );
 
-      const houseId = await createMockHouse(mockHouseData.name, accountId);
+      await createMockHouse(
+        mockHouseData1.name,
+        mockHouseData1.houseId,
+        accountId,
+      );
 
       const [sessionToken] = await createMockSession(accountId, 1);
 
+      const mockBookingId = "a5d72994-80eb-45c7-8351-c3e0fa3c3d20";
+
       const mockBookingData = {
+        bookingId: mockBookingId,
         arrivalTime: addDays(new Date(), 1),
         departureTime: addDays(new Date(), 5),
         comments: "Eager to be there!",
@@ -67,14 +76,15 @@ describe("Bookings", () => {
       };
 
       const response = await request(server)
-        .post(`/houses/${houseId}/bookings/booking`)
+        .post(`/houses/${mockHouseData1.houseId}/bookings/booking`)
         .send(mockBookingData)
         .set("Cookie", [`laperette_session=${sessionToken}`]);
 
       const newBookingRow = await knex("bookings")
         .where({
+          booking_id: mockBookingId,
           booker_id: accountId,
-          house_id: houseId,
+          house_id: mockHouseData1.houseId,
           comments: mockBookingData.comments,
           companions: mockBookingData.companions,
         })
@@ -94,7 +104,11 @@ describe("Bookings", () => {
           mockNewAccountData.password,
         );
 
-        const houseId = await createMockHouse(mockHouseData.name, accountId);
+        await createMockHouse(
+          mockHouseData1.name,
+          mockHouseData1.houseId,
+          accountId,
+        );
 
         const [sessionToken] = await createMockSession(accountId, 1);
 
@@ -112,14 +126,14 @@ describe("Bookings", () => {
         };
 
         const response = await request(server)
-          .post(`/houses/${houseId}/bookings/booking`)
+          .post(`/houses/${mockHouseData1.houseId}/bookings/booking`)
           .send(mockInvalidBookingData)
           .set("Cookie", [`laperette_session=${sessionToken}`]);
 
         const newBookingRow = await knex("bookings")
           .where({
             booker_id: accountId,
-            house_id: houseId,
+            house_id: mockHouseData1.houseId,
             comments: mockInvalidBookingData.comments,
             companions: mockInvalidBookingData.companions,
           })
@@ -146,12 +160,16 @@ describe("Bookings", () => {
         mockNewAccountData.password,
       );
 
-      const houseId = await createMockHouse(mockHouseData.name, accountId);
+      await createMockHouse(
+        mockHouseData1.name,
+        mockHouseData1.houseId,
+        accountId,
+      );
 
       const [[sessionToken], [bookingId1], [bookingId2]] = await Promise.all([
         createMockSession(accountId, 1),
-        createMockBooking(accountId, 3, 3, "pending", houseId),
-        createMockBooking(accountId, 6, 3, "pending", houseId),
+        createMockBooking(accountId, 3, 3, "pending", mockHouseData1.houseId),
+        createMockBooking(accountId, 6, 3, "pending", mockHouseData1.houseId),
       ]);
 
       const response = await request(server)
@@ -177,9 +195,9 @@ describe("Bookings", () => {
         mockNewAccountData.password,
       );
 
-      const [houseId1, houseId2] = await Promise.all([
-        createMockHouse(mockHouseData.name, accountId), // House 1
-        createMockHouse(mockHouseData2.name, accountId), // House 2
+      await Promise.all([
+        createMockHouse(mockHouseData1.name, mockHouseData1.houseId, accountId), // House 1
+        createMockHouse(mockHouseData2.name, mockHouseData2.houseId, accountId), // House 2
       ]);
 
       const [
@@ -189,9 +207,9 @@ describe("Bookings", () => {
         [bookingId3],
       ] = await Promise.all([
         createMockSession(accountId, 1),
-        createMockBooking(accountId, 3, 3, "pending", houseId1), // House 1 booking
-        createMockBooking(accountId, 6, 3, "pending", houseId1), // House 1 booking
-        createMockBooking(accountId, 6, 3, "pending", houseId2), // House 2 booking
+        createMockBooking(accountId, 3, 3, "pending", mockHouseData1.houseId), // House 1 booking
+        createMockBooking(accountId, 6, 3, "pending", mockHouseData1.houseId), // House 1 booking
+        createMockBooking(accountId, 6, 3, "pending", mockHouseData2.houseId), // House 2 booking
       ]);
 
       const response = await request(server)
@@ -227,9 +245,17 @@ describe("Bookings", () => {
         ),
       ]);
 
-      const houseId = await createMockHouse(mockHouseData.name, accountId1);
+      await createMockHouse(
+        mockHouseData1.name,
+        mockHouseData1.houseId,
+        accountId1,
+      );
 
-      await addMockAccountToMockHouse(accountId2, houseId, false);
+      await addMockAccountToMockHouse(
+        accountId2,
+        mockHouseData1.houseId,
+        false,
+      );
 
       const [
         [sessionToken],
@@ -238,9 +264,9 @@ describe("Bookings", () => {
         [bookingId3],
       ] = await Promise.all([
         createMockSession(accountId1, 1),
-        createMockBooking(accountId1, 3, 3, "pending", houseId), // Account 1 booking
-        createMockBooking(accountId1, 1, 3, "pending", houseId), // Account 1 booking
-        createMockBooking(accountId2, 8, 3, "pending", houseId), // Account 2 booking
+        createMockBooking(accountId1, 3, 3, "pending", mockHouseData1.houseId), // Account 1 booking
+        createMockBooking(accountId1, 1, 3, "pending", mockHouseData1.houseId), // Account 1 booking
+        createMockBooking(accountId2, 8, 3, "pending", mockHouseData1.houseId), // Account 2 booking
       ]);
 
       const response = await request(server)
@@ -269,12 +295,16 @@ describe("Bookings", () => {
         mockNewAccountData.password,
       );
 
-      const houseId = await createMockHouse(mockHouseData.name, accountId);
+      await createMockHouse(
+        mockHouseData1.name,
+        mockHouseData1.houseId,
+        accountId,
+      );
 
       const [[sessionToken], [bookingId1], [bookingId2]] = await Promise.all([
         createMockSession(accountId, 1),
-        createMockBooking(accountId, 0, 3, "pending", houseId),
-        createMockBooking(accountId, 0, 3, "pending", houseId),
+        createMockBooking(accountId, 0, 3, "pending", mockHouseData1.houseId),
+        createMockBooking(accountId, 0, 3, "pending", mockHouseData1.houseId),
       ]);
 
       const today = new Date();
@@ -282,7 +312,7 @@ describe("Bookings", () => {
       const intervalEnd = lastDayOfMonth(today);
 
       const response = await request(server)
-        .get(`/houses/${houseId}/bookings`)
+        .get(`/houses/${mockHouseData1.houseId}/bookings`)
         .query({
           start: intervalStart,
           end: intervalEnd,
@@ -308,14 +338,24 @@ describe("Bookings", () => {
         mockNewAccountData.password,
       );
 
-      const houseId = await createMockHouse(mockHouseData.name, accountId);
+      await createMockHouse(
+        mockHouseData1.name,
+        mockHouseData1.houseId,
+        accountId,
+      );
 
       const twoMonthsAwayDate = 65;
 
       const [[sessionToken], [bookingId1], [bookingId2]] = await Promise.all([
         createMockSession(accountId, 1),
-        createMockBooking(accountId, 1, 3, "pending", houseId), // Inside interval booking
-        createMockBooking(accountId, twoMonthsAwayDate, 3, "pending", houseId), // Outside interval booking
+        createMockBooking(accountId, 1, 3, "pending", mockHouseData1.houseId), // Inside interval booking
+        createMockBooking(
+          accountId,
+          twoMonthsAwayDate,
+          3,
+          "pending",
+          mockHouseData1.houseId,
+        ), // Outside interval booking
       ]);
 
       const today = new Date();
@@ -324,7 +364,7 @@ describe("Bookings", () => {
       const intervalEnd = lastDayOfMonth(today);
 
       const response = await request(server)
-        .get(`/houses/${houseId}/bookings`)
+        .get(`/houses/${mockHouseData1.houseId}/bookings`)
         .query({
           start: intervalStart,
           end: intervalEnd,
@@ -350,13 +390,21 @@ describe("Bookings", () => {
         mockNewAccountData.password,
       );
 
-      const houseId1 = await createMockHouse(mockHouseData.name, accountId);
-      const houseId2 = await createMockHouse(mockHouseData.name, accountId);
+      await createMockHouse(
+        mockHouseData1.name,
+        mockHouseData1.houseId,
+        accountId,
+      );
+      await createMockHouse(
+        mockHouseData2.name,
+        mockHouseData2.houseId,
+        accountId,
+      );
 
       const [[sessionToken], [bookingId1], [bookingId2]] = await Promise.all([
         createMockSession(accountId, 1),
-        createMockBooking(accountId, 1, 3, "pending", houseId1), // First house booking
-        createMockBooking(accountId, 1, 3, "pending", houseId2), // Second house booking
+        createMockBooking(accountId, 1, 3, "pending", mockHouseData1.houseId), // First house booking
+        createMockBooking(accountId, 1, 3, "pending", mockHouseData2.houseId), // Second house booking
       ]);
 
       const today = new Date();
@@ -365,7 +413,7 @@ describe("Bookings", () => {
       const intervalEnd = lastDayOfMonth(today);
 
       const response = await request(server)
-        .get(`/houses/${houseId1}/bookings`)
+        .get(`/houses/${mockHouseData1.houseId}/bookings`)
         .query({
           start: intervalStart,
           end: intervalEnd,
@@ -393,11 +441,15 @@ describe("Bookings", () => {
         mockNewAccountData.password,
       );
 
-      const houseId = await createMockHouse(mockHouseData.name, accountId);
+      await createMockHouse(
+        mockHouseData1.name,
+        mockHouseData1.houseId,
+        accountId,
+      );
 
       const [[sessionToken], [bookingId]] = await Promise.all([
         createMockSession(accountId, 1),
-        createMockBooking(accountId, 0, 3, "accepted", houseId),
+        createMockBooking(accountId, 0, 3, "accepted", mockHouseData1.houseId),
       ]);
 
       const mockNewData = {
@@ -431,11 +483,21 @@ describe("Bookings", () => {
           mockNewAccountData.password,
         );
 
-        const houseId = await createMockHouse(mockHouseData.name, accountId);
+        await createMockHouse(
+          mockHouseData1.name,
+          mockHouseData1.houseId,
+          accountId,
+        );
 
         const [[sessionToken], [bookingId]] = await Promise.all([
           createMockSession(accountId, 1),
-          createMockBooking(accountId, 0, 3, "accepted", houseId),
+          createMockBooking(
+            accountId,
+            0,
+            3,
+            "accepted",
+            mockHouseData1.houseId,
+          ),
         ]);
 
         const mockInvalidNewData = {
@@ -471,11 +533,15 @@ describe("Bookings", () => {
         mockNewAccountData.password,
       );
 
-      const houseId = await createMockHouse(mockHouseData.name, accountId);
+      await createMockHouse(
+        mockHouseData1.name,
+        mockHouseData1.houseId,
+        accountId,
+      );
 
       const [[sessionToken], [bookingId]] = await Promise.all([
         createMockSession(accountId, 1),
-        createMockBooking(accountId, 0, 3, "accepted", houseId),
+        createMockBooking(accountId, 0, 3, "accepted", mockHouseData1.houseId),
       ]);
 
       const response = await request(server)

--- a/packages/server/src/controllers/bookings.integration.test.ts
+++ b/packages/server/src/controllers/bookings.integration.test.ts
@@ -461,4 +461,35 @@ describe("Bookings", () => {
       });
     });
   });
+
+  describe("Delete a booking: /bookings/:bookingId", () => {
+    it("should delete the booking", async () => {
+      const [accountId] = await createMockAccount(
+        mockNewAccountData.firstName,
+        mockNewAccountData.lastName,
+        mockNewAccountData.email,
+        mockNewAccountData.password,
+      );
+
+      const houseId = await createMockHouse(mockHouseData.name, accountId);
+
+      const [[sessionToken], [bookingId]] = await Promise.all([
+        createMockSession(accountId, 1),
+        createMockBooking(accountId, 0, 3, "accepted", houseId),
+      ]);
+
+      const response = await request(server)
+        .del(`/bookings/${bookingId}`)
+        .set("Cookie", [`laperette_session=${sessionToken}`]);
+
+      const deletedBookingRow = await knex("bookings")
+        .where({
+          booking_id: bookingId,
+        })
+        .first();
+
+      expect(response.status).toStrictEqual(204);
+      expect(deletedBookingRow).toBeUndefined();
+    });
+  });
 });

--- a/packages/server/src/controllers/bookings.ts
+++ b/packages/server/src/controllers/bookings.ts
@@ -5,6 +5,7 @@ import {
   retrieveHouseBookingsByInterval,
   insertOneBooking,
   retrieveBookingsByAccountId,
+  deleteBookingById,
 } from "../db/bookings";
 import {
   validateNewBookingData,
@@ -250,6 +251,26 @@ export const updateBooking = async (ctx: Context) => {
 
     logger.error(errorMessage, {
       bookingId: booking.bookingId,
+      error: sanitizeError(error),
+    });
+
+    ctx.status = 500;
+    ctx.message = errorMessage;
+  }
+};
+
+export const deleteBooking = async (ctx: Context) => {
+  const { bookingId } = ctx.params;
+  try {
+    await deleteBookingById(bookingId);
+
+    ctx.status = 204;
+    ctx.message = "Booking deleted";
+  } catch (error) {
+    const errorMessage = "Error while deleting a booking";
+
+    logger.error(errorMessage, {
+      bookingId: bookingId,
       error: sanitizeError(error),
     });
 

--- a/packages/server/src/controllers/bookings.ts
+++ b/packages/server/src/controllers/bookings.ts
@@ -23,11 +23,18 @@ export const createBooking = async (ctx: Context) => {
   const { accountId } = ctx.state;
   const { houseId } = ctx.params;
 
-  const { arrivalTime, departureTime, comments, companions } = ctx.request.body;
+  const {
+    bookingId,
+    arrivalTime,
+    departureTime,
+    comments,
+    companions,
+  } = ctx.request.body;
 
   try {
     const newBookingData = {
       accountId,
+      bookingId,
       arrivalTime,
       departureTime,
       comments,
@@ -47,17 +54,17 @@ export const createBooking = async (ctx: Context) => {
 
     const serializedBooking = serializeBookingForDBInsert(newBookingData);
 
-    const newBookingId = await insertOneBooking(serializedBooking);
+    await insertOneBooking(serializedBooking);
 
     const successMessage = "New booking created";
     logger.info(successMessage, {
       accountId: accountId,
-      bookingId: newBookingId,
+      bookingId: bookingId,
     });
     ctx.status = 201;
     ctx.message = successMessage;
     ctx.body = {
-      bookingId: newBookingId,
+      bookingId: bookingId,
     };
   } catch (error) {
     const errorMessage = "Error while creating a booking";

--- a/packages/server/src/controllers/houses.integration.test.ts
+++ b/packages/server/src/controllers/houses.integration.test.ts
@@ -32,14 +32,17 @@ const mockNewAccountData3 = {
 };
 
 const mockHouseData1 = {
+  houseId: "a5d72994-80eb-45c7-8351-c3e0fa3c3d80",
   name: "Longwood House",
 };
 
 const mockInvalidHouseData = {
+  houseId: "invaliduuid",
   name: "    ",
 };
 
 const mockHouseData2 = {
+  houseId: "a5d72994-80eb-45c7-8351-c3e0fa3c3d81",
   name: "La Confiance",
 };
 
@@ -72,13 +75,14 @@ describe("Houses", () => {
 
       const newHouseRow = await knex("houses")
         .where({
+          house_id: mockHouseData1.houseId,
           name: mockHouseData1.name,
         })
         .first();
 
       const newHouseMembershipRow = await knex("house_memberships")
         .where({
-          house_id: newHouseRow.house_id,
+          house_id: mockHouseData1.houseId,
           account_id: accountId,
           is_admin: true,
         })
@@ -107,6 +111,7 @@ describe("Houses", () => {
 
         const newHouseRow = await knex("houses")
           .where({
+            // house_id: mockInvalidHouseData.houseId,
             name: mockInvalidHouseData.name,
           })
           .first();
@@ -134,9 +139,9 @@ describe("Houses", () => {
         mockNewAccountData1.password,
       );
 
-      const [houseId1, houseId2] = await Promise.all([
-        createMockHouse(mockHouseData1.name, accountId),
-        createMockHouse(mockHouseData2.name, accountId),
+      await Promise.all([
+        createMockHouse(mockHouseData1.name, mockHouseData1.houseId, accountId),
+        createMockHouse(mockHouseData2.name, mockHouseData2.houseId, accountId),
       ]);
 
       const [sessionToken] = await createMockSession(accountId, 1);
@@ -153,8 +158,8 @@ describe("Houses", () => {
         (house: HouseForClient) => house.houseId,
       );
 
-      expect(houseIds.includes(houseId1)).toBeTruthy();
-      expect(houseIds.includes(houseId2)).toBeTruthy();
+      expect(houseIds.includes(mockHouseData1.houseId)).toBeTruthy();
+      expect(houseIds.includes(mockHouseData2.houseId)).toBeTruthy();
     });
 
     it("should not return houses from another account", async () => {
@@ -173,9 +178,19 @@ describe("Houses", () => {
         ),
       ]);
 
-      const [houseId1, houseId2] = await Promise.all([
-        createMockHouse(mockHouseData1.name, accountId1), // Account 1 house
-        createMockHouse(mockHouseData1.name, accountId2), // Account 2 house
+      await Promise.all([
+        // Account 1 house
+        createMockHouse(
+          mockHouseData1.name,
+          mockHouseData1.houseId,
+          accountId1,
+        ),
+        // Account 2 house
+        createMockHouse(
+          mockHouseData2.name,
+          mockHouseData2.houseId,
+          accountId2,
+        ),
       ]);
 
       const [sessionToken] = await createMockSession(accountId1, 1); // Account 1 session
@@ -192,8 +207,8 @@ describe("Houses", () => {
         (house: HouseForClient) => house.houseId,
       );
 
-      expect(houseIds.includes(houseId1)).toBeTruthy(); // Account 1 house
-      expect(houseIds.includes(houseId2)).toBeFalsy(); // Account 2 house
+      expect(houseIds.includes(mockHouseData1.houseId)).toBeTruthy(); // Account 1 house
+      expect(houseIds.includes(mockHouseData2.houseId)).toBeFalsy(); // Account 2 house
     });
   });
 
@@ -214,12 +229,16 @@ describe("Houses", () => {
         ),
       ]);
 
-      const houseId1 = await createMockHouse(mockHouseData1.name, accountId1);
+      await createMockHouse(
+        mockHouseData1.name,
+        mockHouseData1.houseId,
+        accountId1,
+      );
 
       const [sessionToken] = await createMockSession(accountId1, 1);
 
       const response = await request(server)
-        .post(`/houses/${houseId1}/members/member`)
+        .post(`/houses/${mockHouseData1.houseId}/members/member`)
         .send({
           newMemberEmail: mockNewAccountData2.email,
         })
@@ -228,7 +247,7 @@ describe("Houses", () => {
       const newMembershipRow = await knex("house_memberships")
         .where({
           account_id: accountId2,
-          house_id: houseId1,
+          house_id: mockHouseData1.houseId,
         })
         .first();
 
@@ -245,12 +264,16 @@ describe("Houses", () => {
           mockNewAccountData1.password,
         );
 
-        const houseId1 = await createMockHouse(mockHouseData1.name, accountId1);
+        await createMockHouse(
+          mockHouseData1.name,
+          mockHouseData1.houseId,
+          accountId1,
+        );
 
         const [sessionToken] = await createMockSession(accountId1, 1);
 
         const response = await request(server)
-          .post(`/houses/${houseId1}/members/member`)
+          .post(`/houses/${mockHouseData1.houseId}/members/member`)
           .send({
             newMemberEmail: mockNewAccountData2.email,
           })
@@ -290,18 +313,22 @@ describe("Houses", () => {
           ),
         ]);
 
-        const houseId1 = await createMockHouse(mockHouseData1.name, accountId1);
+        await createMockHouse(
+          mockHouseData1.name,
+          mockHouseData1.houseId,
+          accountId1,
+        );
 
         await knex("house_memberships").insert({
           account_id: accountId3,
-          house_id: houseId1,
+          house_id: mockHouseData1.houseId,
           is_admin: false,
         });
 
         const [sessionToken] = await createMockSession(accountId3, 1); // Logged in account not admin
 
         const response = await request(server)
-          .post(`/houses/${houseId1}/members/member`)
+          .post(`/houses/${mockHouseData1.houseId}/members/member`)
           .send({
             newMemberEmail: mockNewAccountData2.email,
           })
@@ -332,18 +359,22 @@ describe("Houses", () => {
           ),
         ]);
 
-        const houseId1 = await createMockHouse(mockHouseData1.name, accountId1);
+        await createMockHouse(
+          mockHouseData1.name,
+          mockHouseData1.houseId,
+          accountId1,
+        );
 
         await knex("house_memberships").insert({
           account_id: accountId2,
-          house_id: houseId1,
+          house_id: mockHouseData1.houseId,
           is_admin: false,
         });
 
         const [sessionToken] = await createMockSession(accountId1, 1);
 
         const response = await request(server)
-          .post(`/houses/${houseId1}/members/member`)
+          .post(`/houses/${mockHouseData1.houseId}/members/member`)
           .send({
             newMemberEmail: mockNewAccountData2.email,
           })

--- a/packages/server/src/controllers/houses.ts
+++ b/packages/server/src/controllers/houses.ts
@@ -17,9 +17,9 @@ import { retrieveAccountByEmail } from "../db/accounts";
 
 export const createHouse = async (ctx: Context) => {
   const { accountId } = ctx.state;
-  const { name } = ctx.request.body;
+  const { name, houseId } = ctx.request.body;
 
-  const newHouseData = { accountId, name };
+  const newHouseData = { accountId, name, houseId };
 
   try {
     const isValidData = !!(await validateNewHouseData(newHouseData));
@@ -36,7 +36,7 @@ export const createHouse = async (ctx: Context) => {
 
     const serializedHouse = serializeHouseForDBInsert(newHouseData);
 
-    const houseId = await insertOneHouse(serializedHouse);
+    await insertOneHouse(serializedHouse);
 
     const successMessage = "New house created";
     logger.info(successMessage, {

--- a/packages/server/src/db/bookings.ts
+++ b/packages/server/src/db/bookings.ts
@@ -95,3 +95,7 @@ export const updateBookingById = async (
 ): Promise<void> => {
   await knex("bookings").update(dataToUpdate).where({ booking_id: bookingId });
 };
+
+export const deleteBookingById = async (bookingId: string): Promise<void> => {
+  await knex("bookings").del().where({ booking_id: bookingId });
+};

--- a/packages/server/src/db/bookings.ts
+++ b/packages/server/src/db/bookings.ts
@@ -82,11 +82,8 @@ export const retrieveHouseBookingsByInterval = async (
 
 export const insertOneBooking = async (
   newBooking: BookingForDBInsert,
-): Promise<string> => {
-  const [bookingId] = await knex("bookings")
-    .insert(newBooking)
-    .returning("booking_id");
-  return bookingId;
+): Promise<void> => {
+  await knex("bookings").insert(newBooking);
 };
 
 export const updateBookingById = async (

--- a/packages/server/src/db/houses.ts
+++ b/packages/server/src/db/houses.ts
@@ -3,17 +3,17 @@ import { HouseFromDB, HouseForDBInsert } from "../types/houses";
 
 export const insertOneHouse = async (
   newHouseProperties: HouseForDBInsert,
-): Promise<string> => {
-  let houseId;
+): Promise<void> => {
   const trx = await knex.transaction();
   try {
-    [houseId] = await trx("houses")
-      .returning("house_id")
-      .insert({ name: newHouseProperties.name });
+    await trx("houses").insert({
+      house_id: newHouseProperties.house_id,
+      name: newHouseProperties.name,
+    });
 
     await trx("house_memberships").insert({
       account_id: newHouseProperties.account_id,
-      house_id: houseId,
+      house_id: newHouseProperties.house_id,
       is_admin: true,
     });
 
@@ -22,7 +22,6 @@ export const insertOneHouse = async (
     trx.rollback();
     throw error;
   }
-  return houseId;
 };
 
 export const retrieveHousesByAccountId = (

--- a/packages/server/src/logger.ts
+++ b/packages/server/src/logger.ts
@@ -14,7 +14,7 @@ export const logger = createLogger({
   level: getLogLevel(),
   format: format.combine(format.colorize(), format.timestamp(), format.json()),
   transports: [new transports.Console()],
-  silent: process.env.NODE_ENV === "test",
+  // silent: process.env.NODE_ENV === "test",
 });
 
 export const sanitizeError = (error: Error) => {

--- a/packages/server/src/middlewares/validateBookingOwnership.integration.test.ts
+++ b/packages/server/src/middlewares/validateBookingOwnership.integration.test.ts
@@ -23,6 +23,7 @@ const mockNewAccountData2 = {
 };
 
 const mockHouseData = {
+  houseId: "a5d72994-80eb-45c7-8351-c3e0fa3c3d80",
   name: "Longwood House",
 };
 
@@ -36,14 +37,18 @@ describe(validateBookingOwnership.name, () => {
         mockNewAccountData1.password,
       );
 
-      const houseId = await createMockHouse(mockHouseData.name, accountId);
+      await createMockHouse(
+        mockHouseData.name,
+        mockHouseData.houseId,
+        accountId,
+      );
 
       const [bookingId] = await createMockBooking(
         accountId,
         3,
         3,
         "pending",
-        houseId,
+        mockHouseData.houseId,
       );
 
       const ctx = createMockContext({
@@ -78,14 +83,18 @@ describe(validateBookingOwnership.name, () => {
         ),
       ]);
 
-      const houseId = await createMockHouse(mockHouseData.name, accountId1);
+      await createMockHouse(
+        mockHouseData.name,
+        mockHouseData.houseId,
+        accountId1,
+      );
 
       const [bookingId] = await createMockBooking(
         accountId1, // First account is the booking owner
         3,
         3,
         "pending",
-        houseId,
+        mockHouseData.houseId,
       );
 
       const ctx = createMockContext({

--- a/packages/server/src/middlewares/validateHouseMembership.integration.test.ts
+++ b/packages/server/src/middlewares/validateHouseMembership.integration.test.ts
@@ -19,6 +19,7 @@ const mockNewAccountData2 = {
 };
 
 const mockHouseData = {
+  houseId: "a5d72994-80eb-45c7-8351-c3e0fa3c3d80",
   name: "Longwood House",
 };
 
@@ -32,14 +33,18 @@ describe(validateHouseMembership.name, () => {
         mockNewAccountData1.password,
       );
 
-      const houseId = await createMockHouse(mockHouseData.name, accountId);
+      await createMockHouse(
+        mockHouseData.name,
+        mockHouseData.houseId,
+        accountId,
+      );
 
       const ctx = createMockContext({
         state: { accountId: accountId },
       });
 
       ctx.params = {
-        houseId,
+        houseId: mockHouseData.houseId,
       };
 
       await validateHouseMembership(ctx, mockNext);
@@ -64,14 +69,18 @@ describe(validateHouseMembership.name, () => {
         ),
       ]);
 
-      const houseId = await createMockHouse(mockHouseData.name, accountId1);
+      await createMockHouse(
+        mockHouseData.name,
+        mockHouseData.houseId,
+        accountId1,
+      );
 
       const ctx = createMockContext({
         state: { accountId: accountId2 }, // Second account is logged in
       });
 
       ctx.params = {
-        houseId,
+        houseId: mockHouseData.houseId,
       };
 
       await validateHouseMembership(ctx, mockNext);

--- a/packages/server/src/routers/privateRouter.ts
+++ b/packages/server/src/routers/privateRouter.ts
@@ -10,6 +10,7 @@ import {
   updateBooking,
   getHouseBookingsByInterval,
   getHouseBooking,
+  deleteBooking,
 } from "../controllers/bookings";
 import { getCurrentAccount } from "../controllers/accounts";
 import {
@@ -40,6 +41,12 @@ privateRouter.put(
   "/bookings/:bookingId",
   validateBookingOwnership,
   updateBooking,
+);
+
+privateRouter.del(
+  "/bookings/:bookingId",
+  validateBookingOwnership,
+  deleteBooking,
 );
 
 privateRouter.get("/houses", getAccountHouses);

--- a/packages/server/src/types/bookings.ts
+++ b/packages/server/src/types/bookings.ts
@@ -32,7 +32,7 @@ export interface NewBookingProperties {
   arrivalTime: string;
   departureTime: string;
   comments: string;
-  companions: number;
+  companions: string;
   houseId: string;
 }
 

--- a/packages/server/src/types/bookings.ts
+++ b/packages/server/src/types/bookings.ts
@@ -28,6 +28,7 @@ export interface BookingForClient {
 }
 
 export interface NewBookingProperties {
+  bookingId: string;
   accountId: string;
   arrivalTime: string;
   departureTime: string;
@@ -44,6 +45,7 @@ export interface UpdatedBookingProperties {
 }
 
 export interface BookingForDBInsert {
+  booking_id: NewBookingProperties["bookingId"];
   booker_id: BookingFromDB["booking_id"];
   arrival_time: string;
   departure_time: string;

--- a/packages/server/src/types/houses.ts
+++ b/packages/server/src/types/houses.ts
@@ -10,10 +10,12 @@ export interface HouseForClient {
 
 export interface NewHouseProperties {
   accountId: string;
+  houseId: string;
   name: string;
 }
 
 export interface HouseForDBInsert {
   account_id: NewHouseProperties["accountId"];
+  house_id: NewHouseProperties["houseId"];
   name: NewHouseProperties["name"];
 }

--- a/packages/server/src/utils/booking.ts
+++ b/packages/server/src/utils/booking.ts
@@ -10,12 +10,14 @@ import {
   BookingForDBUpdate,
 } from "../types/bookings";
 import { logger } from "../logger";
+import { isUuid } from "./regexp";
 
 export const validateNewBookingData = async (
   newBookingData: NewBookingProperties,
 ): Promise<boolean> => {
   const {
     accountId,
+    bookingId,
     arrivalTime,
     departureTime,
     comments,
@@ -27,6 +29,16 @@ export const validateNewBookingData = async (
   if (!isAccounValid) {
     logger.error("Invalid account id", {
       accountId: accountId,
+    });
+    return false;
+  }
+
+  const isBookingIdValid = !!validateBookingId(bookingId);
+
+  if (!isBookingIdValid) {
+    logger.error("Invalid booking id", {
+      accountId: accountId,
+      bookingId: bookingId,
     });
     return false;
   }
@@ -198,6 +210,19 @@ const validateCompanions = (
   return false;
 };
 
+const validateBookingId = (bookingId: string) => {
+  /**
+   * Reflection needed over houseId uniqueness validation since houseId uuid is client generated.
+   * Possibility to query DB to check uuid not in DB yet but would impact perfomance
+   */
+
+  if (isUuid(bookingId)) {
+    return true;
+  }
+
+  return false;
+};
+
 export const haveBookingDatesChanged = (
   bookingToBeUpdated: BookingFromDB,
   departureTime: string,
@@ -221,6 +246,7 @@ export const serializeBookingForDBInsert = (
   bookingProperties: NewBookingProperties,
 ): BookingForDBInsert => ({
   booker_id: bookingProperties.accountId,
+  booking_id: bookingProperties.bookingId,
   arrival_time: bookingProperties.arrivalTime,
   departure_time: bookingProperties.departureTime,
   comments: bookingProperties.comments,

--- a/packages/server/src/utils/booking.ts
+++ b/packages/server/src/utils/booking.ts
@@ -184,11 +184,18 @@ const validateComments = (
 const validateCompanions = (
   companions: NewBookingProperties["companions"],
 ): boolean => {
-  if (typeof companions !== "number") {
-    return false;
+  if (typeof companions === "number") {
+    return true;
   }
 
-  return true;
+  if (
+    typeof companions === "string" &&
+    typeof parseInt(companions, 10) === "number"
+  ) {
+    return true;
+  }
+
+  return false;
 };
 
 export const haveBookingDatesChanged = (
@@ -217,7 +224,7 @@ export const serializeBookingForDBInsert = (
   arrival_time: bookingProperties.arrivalTime,
   departure_time: bookingProperties.departureTime,
   comments: bookingProperties.comments,
-  companions: bookingProperties.companions,
+  companions: parseInt(bookingProperties.companions, 10),
   status: "pending" as BookingStatus,
   house_id: bookingProperties.houseId,
 });
@@ -228,7 +235,7 @@ export const serializeBookingForDBUpdate = (
   arrival_time: bookingProperties.arrivalTime,
   departure_time: bookingProperties.departureTime,
   comments: bookingProperties.comments,
-  companions: bookingProperties.companions,
+  companions: parseInt(bookingProperties.companions, 10),
   status: "pending" as BookingStatus,
 });
 

--- a/packages/server/src/utils/houses.ts
+++ b/packages/server/src/utils/houses.ts
@@ -2,9 +2,11 @@ import {
   HouseFromDB,
   HouseForClient,
   NewHouseProperties,
+  HouseForDBInsert,
 } from "../types/houses";
 import { logger } from "../logger";
 import { validateAccountId } from "./account";
+import { isUuid } from "./regexp";
 
 export const serializeHouseForClient = (
   house: HouseFromDB,
@@ -15,20 +17,30 @@ export const serializeHouseForClient = (
 
 export const serializeHouseForDBInsert = (
   newHouseProperties: NewHouseProperties,
-) => ({
+): HouseForDBInsert => ({
   account_id: newHouseProperties.accountId,
+  house_id: newHouseProperties.houseId,
   name: newHouseProperties.name,
 });
 
 export const validateNewHouseData = async (
   newHouseProperties: NewHouseProperties,
 ): Promise<boolean> => {
-  const { accountId, name } = newHouseProperties;
+  const { accountId, name, houseId } = newHouseProperties;
 
   const isAccounValid = !!(await validateAccountId(accountId));
 
   if (!isAccounValid) {
     logger.error("Invalid account id", {
+      accountId: accountId,
+    });
+    return false;
+  }
+
+  const isHouseIdValid = !!(await validateHouseId(houseId));
+
+  if (!isHouseIdValid) {
+    logger.error("Invalid house id", {
       accountId: accountId,
     });
     return false;
@@ -57,4 +69,17 @@ const validateName = (name: NewHouseProperties["name"]): boolean => {
   }
 
   return true;
+};
+
+const validateHouseId = (houseId: NewHouseProperties["houseId"]): boolean => {
+  /**
+   * Reflection needed over houseId uniqueness validation since houseId uuid is client generated.
+   * Possibility to query DB to check uuid not in DB yet but would impact perfomance
+   */
+
+  if (isUuid(houseId)) {
+    return true;
+  }
+
+  return false;
 };

--- a/packages/server/src/utils/regexp.ts
+++ b/packages/server/src/utils/regexp.ts
@@ -1,0 +1,4 @@
+export const isUuid = (id: string) =>
+  new RegExp(
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+  ).test(id);

--- a/packages/server/src/utils/tests.ts
+++ b/packages/server/src/utils/tests.ts
@@ -22,12 +22,13 @@ export const createMockAccount = async (
 
 export const createMockHouse = async (
   houseName: string,
+  houseId: string,
   accountId: string,
-): Promise<string | undefined> => {
+): Promise<void> => {
   const trx = await knex.transaction();
   try {
-    const [houseId]: string = await trx("houses")
-      .insert({ name: houseName })
+    await trx("houses")
+      .insert({ house_id: houseId, name: houseName })
       .returning("house_id");
     await trx("house_memberships").insert({
       account_id: accountId,
@@ -35,7 +36,6 @@ export const createMockHouse = async (
       is_admin: true,
     });
     trx.commit();
-    return houseId;
   } catch (error) {
     logger.error(error);
     trx.rollback();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1265,7 +1265,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.8.3":
+"@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.6.0", "@babel/runtime@^7.8.3":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.1.tgz#b4116a6b6711d010b2dad3b7b6e43bf1b9954740"
   integrity sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==
@@ -1417,6 +1417,18 @@
     colorspace "1.1.x"
     enabled "2.0.x"
     kuler "^2.0.0"
+
+"@date-io/core@1.x", "@date-io/core@^1.3.13":
+  version "1.3.13"
+  resolved "https://registry.yarnpkg.com/@date-io/core/-/core-1.3.13.tgz#90c71da493f20204b7a972929cc5c482d078b3fa"
+  integrity sha512-AlEKV7TxjeK+jxWVKcCFrfYAk8spX9aCyiToFIiLPtfQbsjmRGLIhb5VZgptQcJdHtLXo7+m0DuurwFgUToQuA==
+
+"@date-io/date-fns@1.3.13":
+  version "1.3.13"
+  resolved "https://registry.yarnpkg.com/@date-io/date-fns/-/date-fns-1.3.13.tgz#7798844041640ab393f7e21a7769a65d672f4735"
+  integrity sha512-yXxGzcRUPcogiMj58wVgFjc9qUYrCnnU9eLcyNbsQCmae4jPuZCDoIBR21j8ZURsM7GRtU62VOw5yNd4dDHunA==
+  dependencies:
+    "@date-io/core" "^1.3.13"
 
 "@emotion/hash@^0.8.0":
   version "0.8.0"
@@ -1904,6 +1916,18 @@
   integrity sha512-GBitL3oBWO0hzBhvA9KxqcowRUsA0qzwKkURyC8nppnC3fw54KPKZ+d4V1Eeg/UnDRSzDaI9nGCdel/eh9AQMg==
   dependencies:
     "@babel/runtime" "^7.4.4"
+
+"@material-ui/pickers@^3.2.10":
+  version "3.2.10"
+  resolved "https://registry.yarnpkg.com/@material-ui/pickers/-/pickers-3.2.10.tgz#19df024895876eb0ec7cd239bbaea595f703f0ae"
+  integrity sha512-B8G6Obn5S3RCl7hwahkQj9sKUapwXWFjiaz/Bsw1fhYFdNMnDUolRiWQSoKPb1/oKe37Dtfszoywi1Ynbo3y8w==
+  dependencies:
+    "@babel/runtime" "^7.6.0"
+    "@date-io/core" "1.x"
+    "@types/styled-jsx" "^2.2.8"
+    clsx "^1.0.2"
+    react-transition-group "^4.0.0"
+    rifm "^0.7.0"
 
 "@material-ui/styles@^4.10.0":
   version "4.10.0"
@@ -2597,6 +2621,13 @@
     "@types/react" "*"
     "@types/react-native" "*"
     csstype "^3.0.2"
+
+"@types/styled-jsx@^2.2.8":
+  version "2.2.8"
+  resolved "https://registry.yarnpkg.com/@types/styled-jsx/-/styled-jsx-2.2.8.tgz#b50d13d8a3c34036282d65194554cf186bab7234"
+  integrity sha512-Yjye9VwMdYeXfS71ihueWRSxrruuXTwKCbzue4+5b2rjnQ//AtyM7myZ1BEhNhBQ/nL/RE7bdToUoLln2miKvg==
+  dependencies:
+    "@types/react" "*"
 
 "@types/superagent@*":
   version "4.1.10"
@@ -4344,7 +4375,7 @@ clone-response@^1.0.2:
   dependencies:
     mimic-response "^1.0.0"
 
-clsx@^1.0.4:
+clsx@^1.0.2, clsx@^1.0.4:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
   integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
@@ -12169,7 +12200,7 @@ react-test-renderer@^16.13.1:
     react-is "^16.8.6"
     scheduler "^0.19.1"
 
-react-transition-group@^4.4.0:
+react-transition-group@^4.0.0, react-transition-group@^4.4.0:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.1.tgz#63868f9325a38ea5ee9535d828327f85773345c9"
   integrity sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==
@@ -12652,6 +12683,13 @@ rgba-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3"
   integrity sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=
+
+rifm@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/rifm/-/rifm-0.7.0.tgz#debe951a9c83549ca6b33e5919f716044c2230be"
+  integrity sha512-DSOJTWHD67860I5ojetXdEQRIBvF6YcpNe53j0vn1vp9EUb9N80EiZTxgP+FkDKorWC8PZw052kTF4C1GOivCQ==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
 
 rimraf@2.6.3:
   version "2.6.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2680,6 +2680,11 @@
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-7.0.3.tgz#45cd03e98e758f8581c79c535afbd4fc27ba7ac8"
   integrity sha512-PUdqTZVrNYTNcIhLHkiaYzoOIaUi5LFg/XLerAdgvwQrUCx+oSbtoBze1AMyvYbcwzUSNC+Isl58SM4Sm/6COw==
 
+"@types/uuid@^8.3.0":
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
+  integrity sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==
+
 "@types/yargs-parser@*":
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"
@@ -14386,7 +14391,7 @@ uuid@^8.0.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.0.0.tgz#bc6ccf91b5ff0ac07bbcdbf1c7c4e150db4dbb6c"
   integrity sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==
 
-uuid@^8.3.0:
+uuid@^8.3.0, uuid@^8.3.1:
   version "8.3.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.1.tgz#2ba2e6ca000da60fce5a196954ab241131e05a31"
   integrity sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==


### PR DESCRIPTION
- Modified state of bookings list and houses list
- Modified api call hooks from frontend
- Allows new house/booking to appear in the UI straight away
- Missing proper reconciliation handling if request fails --> Keen to have your insights on this 
- Missing refacto/best practices to follow --> Keen to have your insights on this